### PR TITLE
Remove submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "arm-ros-firmware/hardware/include/arm-firmware-lib/arm-firmware-lib"]
-	path = arm-ros-firmware/hardware/include/arm-firmware-lib/arm-firmware-lib
-	url = git@github.com:UMRoboticsTeam/arm-firmware-lib.git

--- a/arm-ros-firmware/CMakeLists.txt
+++ b/arm-ros-firmware/CMakeLists.txt
@@ -22,9 +22,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 find_package(Boost REQUIRED COMPONENTS log log_setup)
 include_directories(${Boost_INCLUDE_DIRS})
 
-# Setup arm-firmware-lib
-add_subdirectory(hardware/include/arm-firmware-lib)
-
 # Setup ros2_control_demo_description
 install(
         DIRECTORY hardware/include/ros2_control_demo_description/diffbot/urdf hardware/include/ros2_control_demo_description/diffbot/rviz
@@ -55,9 +52,6 @@ ament_target_dependencies(
 
 target_link_libraries(arm_ros_firmware PRIVATE ${Boost_LIBRARIES})
 target_link_libraries(arm_ros_firmware PRIVATE arm_firmware_lib)
-target_include_directories(arm_ros_firmware PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hardware/include/arm-firmware-lib/arm-firmware-lib>
-        )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/arm-ros-firmware/CMakeLists.txt
+++ b/arm-ros-firmware/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 
 # Fixes intellisense not finding ros2 headers https://youtrack.jetbrains.com/issue/CPP-29747/Certain-ROS2-package-headers-missing-from-Intellisense-when-using-a-Docker-toolchain
 include_directories(SYSTEM /opt/ros/$ENV{ROS_DISTRO}/include)
+include(CMakeFindDependencyMacro)
 
 # find dependencies
 set(THIS_PACKAGE_INCLUDE_DEPENDS
@@ -16,23 +17,18 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
         pluginlib
         rclcpp
         rclcpp_lifecycle
+        ament_cmake
+        umrt-arm-firmware-lib
         )
-
-# Setup Boost
-find_package(Boost REQUIRED COMPONENTS log log_setup)
-include_directories(${Boost_INCLUDE_DIRS})
+foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+    find_package(${Dependency} CONFIG REQUIRED)
+endforeach()
 
 # Setup ros2_control_demo_description
 install(
         DIRECTORY hardware/include/ros2_control_demo_description/diffbot/urdf hardware/include/ros2_control_demo_description/diffbot/rviz
         DESTINATION share/${PROJECT_NAME}/ros2_control_demo_description/diffbot
 )
-
-# find dependencies
-find_package(ament_cmake REQUIRED)
-foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
-    find_package(${Dependency} REQUIRED)
-endforeach()
 
 add_library(
         arm_ros_firmware
@@ -49,9 +45,8 @@ ament_target_dependencies(
         arm_ros_firmware PUBLIC
         ${THIS_PACKAGE_INCLUDE_DEPENDS}
 )
-
-target_link_libraries(arm_ros_firmware PRIVATE ${Boost_LIBRARIES})
-target_link_libraries(arm_ros_firmware PRIVATE arm_firmware_lib)
+# ament_target_dependencies doesn't use namespaces when linking, so we need to link umrt-arm-firmware-lib ourself
+target_link_libraries(arm_ros_firmware PRIVATE umrt-arm-firmware-lib::umrt-arm-firmware-lib)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/arm-ros-firmware/hardware/StepperAdapter.cpp
+++ b/arm-ros-firmware/hardware/StepperAdapter.cpp
@@ -7,6 +7,12 @@
 constexpr boost::log::trivial::severity_level LOG_LEVEL = boost::log::trivial::debug;
 constexpr uint32_t TOTAL_LOG_SIZE = 100 * 1024 * 1024; // 100 MiB
 
+StepperAdapter::~StepperAdapter() {
+    if (this->initialized) {
+        this->disconnect();
+    }
+}
+
 void StepperAdapter::init(
         const std::size_t NUM_JOINTS,
         const std::chrono::duration<int64_t, std::milli>& query_period
@@ -30,17 +36,15 @@ void StepperAdapter::init(
     this->positions_buffer.resize(NUM_JOINTS);
     this->velocities_buffer.resize(NUM_JOINTS);
 
-    // Start the polling loop
-    this->polling_thread = std::thread(&StepperAdapter::poll, this);
-
     // Register to receive callbacks for responses to getPosition and getSpeed
     // Note: These callbacks will occur in another thread, so they need to be processed carefully
     this->controller.EGetPosition.connect([this](uint8_t joint, int32_t pos) -> void { this->updatePosition(joint, pos); });
     this->controller.EGetSpeed.connect([this](uint8_t joint, int16_t speed) -> void { this->updateVelocity(joint, speed); });
 
-    // Start the joint state querying loop
-    this->query_motors = true;
-    this->timer = std::thread([this, query_period]() -> void { this->queryPoll(query_period); });
+    // Start the polling loops for message handling and joint state querying
+    this->continue_polling = true;
+    this->polling_thread = std::thread([this]() -> void { this->poll(); });
+    this->querying_thread = std::thread([this, query_period]() -> void { this->queryPoll(query_period); });
 
     this->initialized = true;
 }
@@ -52,7 +56,7 @@ void StepperAdapter::connect(const std::string device, const int baud_rate) {
 
 void StepperAdapter::disconnect() {
     initializedCheck();
-    this->query_motors = false;
+    this->continue_polling = false;
     this->controller.disconnect();
 }
 
@@ -108,9 +112,9 @@ void StepperAdapter::readValues() {
 }
 
 [[noreturn]] void StepperAdapter::poll() {
-    // Run update loop forever
+    // Run update loop approximately forever
     // TODO: Look into a better way of doing the polling loop which isn't so intensive
-    for (;;) {
+    while (continue_polling) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
         this->controller.update();
     }
@@ -146,8 +150,8 @@ void StepperAdapter::initializedCheck() {
 }
 
 void StepperAdapter::queryPoll(const std::chrono::milliseconds& period) {
-    while (this->query_motors) {
-        this->queryController();
+    while (this->continue_polling) {
         std::this_thread::sleep_for(period);
+        this->queryController();
     }
 }

--- a/arm-ros-firmware/hardware/diffbot_system.cpp
+++ b/arm-ros-firmware/hardware/diffbot_system.cpp
@@ -129,7 +129,7 @@ hardware_interface::CallbackReturn DiffBotSystemHardware::on_init(
     }
   }
 
-  steppers.init(info_.joints.size());
+  steppers.init(info_.joints.size(), std::chrono::milliseconds(100));
 
   return hardware_interface::CallbackReturn::SUCCESS;
 }

--- a/arm-ros-firmware/hardware/include/arm-firmware-lib/CMakeLists.txt
+++ b/arm-ros-firmware/hardware/include/arm-firmware-lib/CMakeLists.txt
@@ -1,1 +1,0 @@
-add_subdirectory(arm-firmware-lib)

--- a/arm-ros-firmware/hardware/include/arm_ros_firmware/StepperAdapter.hpp
+++ b/arm-ros-firmware/hardware/include/arm_ros_firmware/StepperAdapter.hpp
@@ -25,13 +25,11 @@ public:
     * facilitate initialization such as array sizing.
     *
     * @param NUM_JOINTS the number of joints
-    * @param parentNode the Node to use for creating WallTimers
-    * @param queryPeriod the time to wait between controller queries for position, velocity, etc.
+    * @param query_period the time to wait between controller queries for position, velocity, etc.
     */
     void init(
             const std::size_t NUM_JOINTS,
-            rclcpp::Node& parentNode,
-            const std::chrono::duration<int64_t, std::milli>& queryPeriod
+            const std::chrono::duration<int64_t, std::milli>& query_period
     );
 
     /**
@@ -177,6 +175,23 @@ protected:
      *                          at the time of calling
      */
     void initializedCheck();
+
+    /**
+     * Poll loop used to trigger motor queries.
+     *
+     * @param period Amount of time to wait in milliseconds between queries
+     */
+    void queryPoll(const std::chrono::milliseconds& period);
+
+    /**
+     * Thread used to periodically query motor speed/position.
+     */
+    std::thread timer;
+
+    /**
+     * Signal used to shutdown the timer thread.
+     */
+    std::atomic<bool> query_motors = false;
 
 private:
     /**

--- a/arm-ros-firmware/hardware/include/arm_ros_firmware/StepperAdapter.hpp
+++ b/arm-ros-firmware/hardware/include/arm_ros_firmware/StepperAdapter.hpp
@@ -9,7 +9,7 @@
 
 #include <rclcpp/node.hpp>
 
-#include "StepperController.h"
+#include <umrt-arm-firmware-lib/StepperController.h>
 
 /**
  * Adapter class to interface a @ref StepperController with a ros2_control


### PR DESCRIPTION
Switched to using pre-built umrt-arm-firmware-lib library instead of a Git submodule. In the process, some unfinished work on motor status polling was completed in order to get the project to build. This has not been tested, but should be (though these motor drivers are not expected to be used anymore).